### PR TITLE
Fix requirement import validator for category field

### DIFF
--- a/app/api/rfps/[rfpId]/requirements/import/route.ts
+++ b/app/api/rfps/[rfpId]/requirements/import/route.ts
@@ -63,9 +63,16 @@ export async function POST(
     const categoryNames = (categories as unknown as Category[]).map(
       (c) => c.title
     );
+    const categoryCodes = (categories as unknown as Category[]).map(
+      (c) => c.code
+    );
 
-    // Validate JSON format
-    const validation = validateRequirementsJSON(body.json, categoryNames);
+    // Validate JSON format (pass both titles and codes)
+    const validation = validateRequirementsJSON(
+      body.json,
+      categoryNames,
+      categoryCodes
+    );
     if (!validation.valid) {
       console.error("Requirements validation failed:", validation.error);
       console.error("Available categories:", categoryNames);

--- a/components/ImportWithStepper.tsx
+++ b/components/ImportWithStepper.tsx
@@ -63,6 +63,7 @@ export function ImportWithStepper({ rfpId }: ImportWithStepperProps) {
   const [categoriesJson, setCategoriesJson] = useState<string>("");
   const [categoriesValid, setCategoriesValid] = useState(false);
   const [existingCategories, setExistingCategories] = useState<string[]>([]);
+  const [existingCategoryCodes, setExistingCategoryCodes] = useState<string[]>([]);
 
   // Step 2: Requirements
   const [requirementsJson, setRequirementsJson] = useState<string>("");
@@ -105,15 +106,19 @@ export function ImportWithStepper({ rfpId }: ImportWithStepperProps) {
       if (!response.ok) return;
 
       const treeData = await response.json();
-      // Extract all category titles from the tree (including nested ones)
+      // Extract all category titles and codes from the tree (including nested ones)
       const titles: string[] = [];
+      const codes: string[] = [];
 
-      const extractTitles = (nodes: any[]) => {
+      const extractCategories = (nodes: any[]) => {
         for (const node of nodes) {
           if (node.type === "category") {
             titles.push(node.title);
+            if (node.code) {
+              codes.push(node.code);
+            }
             if (node.children) {
-              extractTitles(
+              extractCategories(
                 node.children.filter((c: any) => c.type === "category")
               );
             }
@@ -121,8 +126,9 @@ export function ImportWithStepper({ rfpId }: ImportWithStepperProps) {
         }
       };
 
-      extractTitles(treeData);
+      extractCategories(treeData);
       setExistingCategories(titles);
+      setExistingCategoryCodes(codes);
     } catch (err) {
       console.error("Failed to load existing categories:", err);
     }
@@ -712,6 +718,9 @@ export function ImportWithStepper({ rfpId }: ImportWithStepperProps) {
                             ) => {
                               const categoryExists =
                                 existingCategories.includes(
+                                  requirement.category_name
+                                ) ||
+                                existingCategoryCodes.includes(
                                   requirement.category_name
                                 );
                               return (

--- a/lib/supabase/validators.ts
+++ b/lib/supabase/validators.ts
@@ -190,7 +190,8 @@ export function validateRequirementsRequest(
 
 export function validateRequirementsJSON(
   jsonString: string,
-  availableCategories: string[]
+  availableCategories: string[],
+  availableCategoryCodes?: string[]
 ): {
   valid: boolean;
   data?: ImportRequirementsRequest;
@@ -212,11 +213,16 @@ export function validateRequirementsJSON(
       };
     }
 
-    // Check that all referenced categories exist
+    // Check that all referenced categories exist (by title or code)
     const categorySet = new Set(availableCategories);
+    const categoryCodeSet = new Set(availableCategoryCodes || []);
 
     for (const requirement of normalizedData.requirements) {
-      if (!categorySet.has(requirement.category_name)) {
+      const categoryExists =
+        categorySet.has(requirement.category_name) ||
+        categoryCodeSet.has(requirement.category_name);
+
+      if (!categoryExists) {
         return {
           valid: false,
           error: `Requirement "${requirement.code}" references non-existent category "${requirement.category_name}"`,


### PR DESCRIPTION
…codes

The validator was only checking category names but not codes, causing validation failures when users provided category codes instead of names. This update:
- Passes both category titles and codes to the validator
- Updates validator to accept either name or code for category_name field
- Updates the preview table to check both names and codes when validating categories

This aligns with the existing dual-lookup in importRequirements() function that already supports both category names and codes.