### PR TITLE
Fix PDF preview close behavior on outside click

### DIFF
--- a/components/PDFViewerSheet.tsx
+++ b/components/PDFViewerSheet.tsx
@@ -264,7 +264,7 @@ export function PDFViewerSheet({
       {isOpen && !isMinimized && (
         <div
           className="fixed inset-0 bg-black/50 z-30"
-          onClick={() => handleOpenChange(false)}
+          onClick={() => setIsMinimized(true)}
         />
       )}
 


### PR DESCRIPTION
When clicking outside the PDF preview panel, the behavior now minimizes the panel (slides it to the right) instead of closing it completely. This makes the behavior consistent with clicking the minimize arrow button.