### PR TITLE
feat: Add quick link to evaluate from analytics requirement popovers

### DIFF
--- a/app/dashboard/rfp/[rfpId]/evaluate/page.tsx
+++ b/app/dashboard/rfp/[rfpId]/evaluate/page.tsx
@@ -38,10 +38,11 @@ export default function EvaluatePage({ params }: EvaluatePageProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const supplierId = searchParams.get("supplierId");
+  const requirementId = searchParams.get("requirementId");
   const { user, isLoading: authLoading } = useAuth();
   const [selectedRequirementId, setSelectedRequirementId] = useState<
     string | null
-  >(null);
+  >(requirementId || null);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [rfpTitle, setRfpTitle] = useState<string>("RFP");
   const [rfpData, setRfpData] = useState<RFP | null>(null);

--- a/components/RFPSummary/RequirementsHeatmap.tsx
+++ b/components/RFPSummary/RequirementsHeatmap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useMemo } from "react";
+import Link from "next/link";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   Select,
@@ -16,7 +17,7 @@ import {
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Info, Search } from "lucide-react";
+import { Info, Search, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import { Supplier } from "@/types/supplier";
@@ -333,13 +334,29 @@ export function RequirementsHeatmap({
                               </Button>
                             </PopoverTrigger>
                             <PopoverContent className="w-80 p-4" align="start">
-                              <div className="space-y-2">
-                                <h4 className="font-medium leading-none">
-                                  Description
-                                </h4>
-                                <p className="text-sm text-muted-foreground">
-                                  {req.description}
-                                </p>
+                              <div className="space-y-3">
+                                <div>
+                                  <h4 className="font-medium leading-none">
+                                    Description
+                                  </h4>
+                                  <p className="text-sm text-muted-foreground">
+                                    {req.description}
+                                  </p>
+                                </div>
+                                <div className="pt-2 border-t">
+                                  <Link
+                                    href={`/dashboard/rfp/${rfpId}/evaluate?requirementId=${req.id}`}
+                                  >
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      className="w-full gap-2"
+                                    >
+                                      <ExternalLink className="h-4 w-4" />
+                                      Voir dans l'évaluation
+                                    </Button>
+                                  </Link>
+                                </div>
                               </div>
                             </PopoverContent>
                           </Popover>


### PR DESCRIPTION
- Add "Voir dans l'évaluation" button in requirement popovers in the analytics tab of /summary page
- Button navigates to /evaluate page with requirementId parameter to auto-select the requirement
- Support requirementId URL parameter in /evaluate page to initialize selectedRequirementId
- Allow quick navigation between analytics view and requirement evaluation

Allows users to seamlessly navigate from summary analytics to evaluate specific requirements.