### PR TITLE
Add supplier metadata endpoint and caching

### DIFF
--- a/app/api/rfps/[rfpId]/responses/route.ts
+++ b/app/api/rfps/[rfpId]/responses/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { verifyRFPAccess } from "@/lib/permissions/rfp-access";
 import { getResponsesForRFP } from "@/lib/supabase/queries";
+import {
+  getActiveSupplierIds,
+  getVersionSupplierStatuses,
+} from "@/lib/suppliers/status-cache";
 
 /**
  * GET /api/rfps/[rfpId]/responses
@@ -23,6 +27,8 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const requirementId = searchParams.get("requirementId") || undefined;
     const versionId = searchParams.get("versionId") || undefined;
+    const supplierId = searchParams.get("supplierId") || undefined;
+    const includeDocs = searchParams.get("includeDocs") !== "false";
 
     // Verify RFP exists and user has access
     const supabase = await createServerClient();
@@ -41,56 +47,58 @@ export async function GET(
     }
 
     // Fetch responses with supplier information, passing versionId if provided
-    let responses = await getResponsesForRFP(rfpId, requirementId, versionId);
+    let responses = await getResponsesForRFP(
+      rfpId,
+      requirementId,
+      versionId,
+      supplierId
+    );
 
     // Filter by supplier status to exclude removed suppliers if version is specified
     if (versionId) {
-      const { data: activeSupplierStatuses } = await supabase
-        .from("version_supplier_status")
-        .select("supplier_id")
-        .eq("version_id", versionId)
-        .in("shortlist_status", ["active", "shortlisted"]);
-
-      const activeSupplierIds = new Set(
-        (activeSupplierStatuses || []).map((status) => status.supplier_id)
-      );
+      const activeStatuses = await getVersionSupplierStatuses(supabase, versionId);
+      const activeSupplierIds = getActiveSupplierIds(activeStatuses);
 
       responses = responses.filter((r) => activeSupplierIds.has(r.supplier_id));
     }
 
-    // Fetch document availability for these suppliers
-    // 1. Get all document IDs for this RFP
-    const { data: rfpDocs } = await supabase
-      .from("rfp_documents")
-      .select("id")
-      .eq("rfp_id", rfpId)
-      .is("deleted_at", null);
+    let enrichedResponses = responses;
 
-    const rfpDocIds = rfpDocs?.map((d) => d.id) || [];
-    const supplierIds = Array.from(
-      new Set(responses.map((r) => r.supplier_id))
-    );
-    const suppliersWithDocs = new Set<string>();
+    if (includeDocs && responses.length > 0) {
+      // Fetch document availability for these suppliers
+      // 1. Get all document IDs for this RFP
+      const { data: rfpDocs } = await supabase
+        .from("rfp_documents")
+        .select("id")
+        .eq("rfp_id", rfpId)
+        .is("deleted_at", null);
 
-    // 2. Check which suppliers are linked to these documents
-    if (rfpDocIds.length > 0 && supplierIds.length > 0) {
-      const { data: docSuppliers } = await supabase
-        .from("document_suppliers")
-        .select("supplier_id")
-        .in("document_id", rfpDocIds)
-        .in("supplier_id", supplierIds);
+      const rfpDocIds = rfpDocs?.map((d) => d.id) || [];
+      const supplierIds = Array.from(
+        new Set(responses.map((r) => r.supplier_id))
+      );
+      const suppliersWithDocs = new Set<string>();
 
-      docSuppliers?.forEach((ds) => suppliersWithDocs.add(ds.supplier_id));
+      // 2. Check which suppliers are linked to these documents
+      if (rfpDocIds.length > 0 && supplierIds.length > 0) {
+        const { data: docSuppliers } = await supabase
+          .from("document_suppliers")
+          .select("supplier_id")
+          .in("document_id", rfpDocIds)
+          .in("supplier_id", supplierIds);
+
+        docSuppliers?.forEach((ds) => suppliersWithDocs.add(ds.supplier_id));
+      }
+
+      // 3. Enrich responses with has_documents flag
+      enrichedResponses = responses.map((response) => ({
+        ...response,
+        supplier: {
+          ...response.supplier,
+          has_documents: suppliersWithDocs.has(response.supplier_id),
+        },
+      }));
     }
-
-    // 3. Enrich responses with has_documents flag
-    const enrichedResponses = responses.map((response) => ({
-      ...response,
-      supplier: {
-        ...response.supplier,
-        has_documents: suppliersWithDocs.has(response.supplier_id),
-      },
-    }));
 
     return NextResponse.json({
       responses: enrichedResponses,

--- a/app/api/rfps/[rfpId]/suppliers/metadata/route.ts
+++ b/app/api/rfps/[rfpId]/suppliers/metadata/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { verifyRFPAccess } from "@/lib/permissions/rfp-access";
+import {
+  getActiveSupplierIds,
+  getVersionSupplierStatuses,
+} from "@/lib/suppliers/status-cache";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { rfpId: string } }
+) {
+  try {
+    const { rfpId } = params;
+    const { searchParams } = new URL(request.url);
+    const versionId = searchParams.get("versionId") || undefined;
+    const supplierId = searchParams.get("supplierId") || undefined;
+    const includeDocs = searchParams.get("includeDocs") !== "false";
+
+    if (!rfpId || typeof rfpId !== "string") {
+      return NextResponse.json({ error: "Invalid RFP ID" }, { status: 400 });
+    }
+
+    const supabase = await createServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const accessCheckResponse = await verifyRFPAccess(rfpId, user.id);
+    if (accessCheckResponse) {
+      return accessCheckResponse;
+    }
+
+    let supplierStatuses: Record<string, { shortlist_status: string | null; is_active: boolean | null }> = {};
+    let supplierIds: string[] = [];
+
+    if (versionId) {
+      const statuses = await getVersionSupplierStatuses(supabase, versionId);
+      supplierStatuses = statuses.reduce((acc, status) => {
+        acc[status.supplier_id] = {
+          shortlist_status: status.shortlist_status,
+          is_active: status.is_active,
+        };
+        return acc;
+      }, {} as Record<string, { shortlist_status: string | null; is_active: boolean | null }>);
+
+      const activeSupplierIds = getActiveSupplierIds(statuses);
+      supplierIds = supplierId
+        ? activeSupplierIds.has(supplierId)
+          ? [supplierId]
+          : []
+        : Array.from(activeSupplierIds);
+    } else {
+      const { data: suppliers, error: suppliersError } = await supabase
+        .from("suppliers")
+        .select("id")
+        .eq("rfp_id", rfpId);
+
+      if (suppliersError) {
+        console.error("Error fetching suppliers for metadata:", suppliersError);
+        return NextResponse.json(
+          { error: "Failed to fetch supplier metadata" },
+          { status: 500 }
+        );
+      }
+
+      supplierIds = (suppliers || []).map((s) => s.id);
+
+      if (supplierId) {
+        supplierIds = supplierIds.filter((id) => id === supplierId);
+      }
+
+      supplierIds.forEach((id) => {
+        supplierStatuses[id] = { shortlist_status: "active", is_active: true };
+      });
+    }
+
+    let suppliersWithDocs = new Set<string>();
+
+    if (includeDocs && supplierIds.length > 0) {
+      const { data: rfpDocs } = await supabase
+        .from("rfp_documents")
+        .select("id")
+        .eq("rfp_id", rfpId)
+        .is("deleted_at", null);
+
+      const rfpDocIds = rfpDocs?.map((d) => d.id) || [];
+
+      if (rfpDocIds.length > 0) {
+        const { data: docSuppliers } = await supabase
+          .from("document_suppliers")
+          .select("supplier_id")
+          .in("document_id", rfpDocIds)
+          .in("supplier_id", supplierIds);
+
+        docSuppliers?.forEach((ds) => suppliersWithDocs.add(ds.supplier_id));
+      }
+    }
+
+    const metadata = supplierIds.map((id) => ({
+      supplier_id: id,
+      shortlist_status: supplierStatuses[id]?.shortlist_status ?? null,
+      is_active: supplierStatuses[id]?.is_active ?? null,
+      has_documents: includeDocs ? suppliersWithDocs.has(id) : undefined,
+    }));
+
+    return NextResponse.json({ suppliers: metadata, count: metadata.length });
+  } catch (error) {
+    console.error("Error in supplier metadata endpoint:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch supplier metadata" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/rfps/[rfpId]/suppliers/route.ts
+++ b/app/api/rfps/[rfpId]/suppliers/route.ts
@@ -1,6 +1,10 @@
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { verifyRFPAccess } from "@/lib/permissions/rfp-access";
 import { NextRequest, NextResponse } from "next/server";
+import {
+  getActiveSupplierIds,
+  getVersionSupplierStatuses,
+} from "@/lib/suppliers/status-cache";
 
 /**
  * GET /api/rfps/[rfpId]/suppliers
@@ -44,39 +48,25 @@ export async function GET(
     let suppliers, suppliersError;
 
     if (versionId) {
-      // Fetch suppliers with their version status
-      const result = await supabase
-        .from("suppliers")
-        .select(
-          `
-          id,
-          name,
-          version_supplier_status!inner (
-            is_active,
-            shortlist_status
+      const statuses = await getVersionSupplierStatuses(supabase, versionId);
+      const activeSupplierIds = getActiveSupplierIds(statuses);
+
+      if (activeSupplierIds.size === 0) {
+        suppliers = [];
+        suppliersError = null;
+      } else {
+        const result = await supabase
+          .from("suppliers")
+          .select(
+            "id, name, supplier_id_external, contact_name, contact_email, contact_phone"
           )
-        `
-        )
-        .eq("rfp_id", rfpId)
-        .eq("version_supplier_status.version_id", versionId)
-        .order("name", { ascending: true });
+          .eq("rfp_id", rfpId)
+          .in("id", Array.from(activeSupplierIds))
+          .order("name", { ascending: true });
 
-      suppliersError = result.error;
-
-      // Filter client-side to exclude removed and inactive suppliers
-      // (Supabase .neq() with nested relations may not work reliably)
-      // version_supplier_status might be an array or object depending on query result
-      suppliers =
-        result.data?.filter((supplier: any) => {
-          const status = supplier.version_supplier_status;
-          const statusObj = Array.isArray(status) ? status[0] : status;
-
-          return (
-            statusObj &&
-            statusObj.is_active === true &&
-            statusObj.shortlist_status !== "removed"
-          );
-        }) || [];
+        suppliers = result.data;
+        suppliersError = result.error;
+      }
     } else {
       // Fetch all suppliers if no versionId provided
       const result = await supabase

--- a/lib/supabase/queries.ts
+++ b/lib/supabase/queries.ts
@@ -872,7 +872,8 @@ export async function getResponsesForRequirement(
 export async function getResponsesForRFP(
   rfpId: string,
   requirementId?: string,
-  versionId?: string
+  versionId?: string,
+  supplierId?: string
 ): Promise<
   Array<{
     id: string;
@@ -944,6 +945,10 @@ export async function getResponsesForRFP(
 
   if (versionId) {
     query = query.eq("version_id", versionId);
+  }
+
+  if (supplierId) {
+    query = query.eq("supplier_id", supplierId);
   }
 
   const { data, error } = await query;

--- a/lib/suppliers/status-cache.ts
+++ b/lib/suppliers/status-cache.ts
@@ -1,0 +1,57 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type VersionSupplierStatusRow = {
+  supplier_id: string;
+  shortlist_status: string | null;
+  is_active: boolean | null;
+};
+
+type CacheEntry = {
+  statuses: VersionSupplierStatusRow[];
+  fetchedAt: number;
+};
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const cache = new Map<string, CacheEntry>();
+
+export async function getVersionSupplierStatuses(
+  supabase: SupabaseClient,
+  versionId: string
+): Promise<VersionSupplierStatusRow[]> {
+  const cached = cache.get(versionId);
+  const now = Date.now();
+
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.statuses;
+  }
+
+  const { data, error } = await supabase
+    .from("version_supplier_status")
+    .select("supplier_id, shortlist_status, is_active")
+    .eq("version_id", versionId);
+
+  if (error) {
+    console.error("Error fetching version supplier statuses:", error);
+    return [];
+  }
+
+  const statuses = data || [];
+  cache.set(versionId, { statuses, fetchedAt: now });
+
+  return statuses;
+}
+
+export function getActiveSupplierIds(
+  statuses: VersionSupplierStatusRow[]
+): Set<string> {
+  return new Set(
+    statuses
+      .filter(
+        (status) =>
+          (status.is_active ?? true) && (status.shortlist_status ?? "active") !== "removed"
+      )
+      .map((status) => status.supplier_id)
+  );
+}
+
+export type { VersionSupplierStatusRow };


### PR DESCRIPTION
## Summary
- cache version supplier status lookups and reuse active supplier filtering
- add supplierId/includeDocs handling for response queries to skip document enrichment when requested
- create supplier metadata endpoint to expose status and document flags independently

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c4c269f908320b3563224ea81a83c)