### PR TITLE
fix: restore full-width sidebar on mobile after resizable sidebar commit

### DIFF
--- a/app/dashboard/rfp/[rfpId]/evaluate/page.tsx
+++ b/app/dashboard/rfp/[rfpId]/evaluate/page.tsx
@@ -417,10 +417,10 @@ export default function EvaluatePage({ params }: EvaluatePageProps) {
         <div className="flex flex-1 overflow-hidden">
           {/* Sidebar with Tree */}
           <div
-            className="flex-shrink-0 flex border-r border-slate-200 bg-white/50 dark:border-slate-800 dark:bg-slate-900/40"
+            className={`${isMobile ? "flex-1 flex" : "flex-shrink-0 flex"} border-r border-slate-200 bg-white/50 dark:border-slate-800 dark:bg-slate-900/40`}
             style={isMobile ? undefined : { width: sidebarWidth }}
           >
-            <div className={isMobile ? "w-full" : "flex-1 min-w-0"}>
+            <div className="flex-1 min-w-0">
               <Sidebar
                 rfpId={params.rfpId}
                 selectedRequirementId={selectedRequirementId}


### PR DESCRIPTION
The resizable sidebar commit replaced `w-full` on the sidebar wrapper
with `flex-shrink-0` (no explicit width), causing the sidebar to
collapse on mobile instead of filling the screen.

On mobile: use `flex-1 flex` so the sidebar expands to fill all
available space (it's the only child — the details panel is hidden).
On desktop: keep `flex-shrink-0` with the explicit `sidebarWidth` style.
Inner div changed to `flex-1 min-w-0` for both breakpoints.

https://claude.ai/code/session_011wmHLByzWkL3kiaG7j8TDj