### PR TITLE
Convert Edge Function calls to fire-and-forget pattern

### DIFF
--- a/app/api/rfps/[rfpId]/analyze-defense/route.ts
+++ b/app/api/rfps/[rfpId]/analyze-defense/route.ts
@@ -100,28 +100,25 @@ export async function POST(
 
     const edgeFunctionUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/analyze-defense`;
 
-    try {
-      const response = await fetch(edgeFunctionUrl, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${process.env.SUPABASE_ANON_KEY}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          analysisId: analysis.id,
-          rfpId,
-          supplierId,
-          versionId: versionId || null,
-          correlationId,
-        }),
-      });
-
-      if (!response.ok) {
-        console.error("Edge Function error:", response.status);
-      }
-    } catch (error) {
-      console.error("Error calling Edge Function:", error);
-    }
+    // Fire-and-forget: do not await the Edge Function call to avoid
+    // Vercel FUNCTION_INVOCATION_TIMEOUT. The Edge Function updates the
+    // defense_analyses record asynchronously; the client polls /results/latest.
+    fetch(edgeFunctionUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.SUPABASE_ANON_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        analysisId: analysis.id,
+        rfpId,
+        supplierId,
+        versionId: versionId || null,
+        correlationId,
+      }),
+    }).catch((error) => {
+      console.error("Error calling Edge Function (analyze-defense):", error);
+    });
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary
Refactored the presentation and defense analysis API routes to use a fire-and-forget pattern for Edge Function calls, preventing Vercel function timeout errors while maintaining asynchronous result processing.

## Key Changes
- **analyze-presentation route**: Removed `await` and try-catch block from Edge Function call, allowing the request to return immediately while the function processes asynchronously
- **analyze-defense route**: Applied the same fire-and-forget pattern to maintain consistency across analysis endpoints
- **Error handling**: Replaced try-catch with `.catch()` chaining to handle network errors without blocking the response
- **Documentation**: Added clarifying comments explaining that Edge Functions update database records asynchronously and clients poll `/results/latest` for results

## Implementation Details
- The API endpoints now return immediately after queuing the analysis work, avoiding Vercel's `FUNCTION_INVOCATION_TIMEOUT`
- Edge Functions continue processing in the background and update their respective database records (`presentation_analyses` and `defense_analyses`)
- Client-side polling mechanism remains unchanged and continues to fetch latest results
- Error logging is preserved with more specific error messages indicating which Edge Function encountered issues

https://claude.ai/code/session_015x4m3qkCmmAWqNZ9yQhtNc