### PR TITLE
fix(export): fix checkbox bullets and table cell multi-line bullets in DOCX

### DIFF
--- a/app/api/export-docx/route.ts
+++ b/app/api/export-docx/route.ts
@@ -121,8 +121,11 @@ function listItemToRuns(item: Tokens.ListItem): TextRun[] {
  *   2. Inline • separator without newlines: "• Q1? • Q2? • Q3?"
  */
 function splitCellContent(raw: string): { isBullet: boolean; content: string }[] {
-    // Normalise literal "\n" (2-char sequence) to a real newline
-    const text = raw.replace(/\\n/g, "\n").trim();
+    // Normalise literal "\n" and <br> tags to real newlines
+    const text = raw
+        .replace(/\\n/g, "\n")
+        .replace(/<br\s*\/?>/gi, "\n")
+        .trim();
 
     // Split on real newlines first
     const lines = text.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);


### PR DESCRIPTION
## Summary

- Remplace `html-to-docx` par `docx` v9 qui génère des fichiers OOXML valides
  → résout le « fichier apparemment endommagé »
- Les items checkbox (☐/☑) ne reçoivent plus de puce • en double
- Les puces dans les cellules de tableau sont chacune sur une ligne séparée
  (gère \n réels, séquences \n littérales, et séparateur • inline)

## Commits

- fix(export): replace html-to-docx with docx library to fix corrupt Word files
- fix(export): fix checkbox bullets and table cell multi-line bullets in DOCX