### PR TITLE
Configure MCP servers for Supabase and Context7 integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,19 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=${SUPABASE_PROJECT_REF}",
+      "headers": {
+        "Authorization": "Bearer ${SUPABASE_ACCESS_TOKEN}"
+      }
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "ctx7sk-42f9886b-446e-4d6a-ad54-e7d8814d261f"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Added Model Context Protocol (MCP) server configurations to enable integration with Supabase and Context7 services.

## Changes
- Added `mcpServers` configuration object to `.claude/settings.json`
- Configured Supabase MCP server with HTTP endpoint and Bearer token authentication using environment variables
- Configured Context7 MCP server with HTTP endpoint and API key authentication
- Both servers are now available for use within Claude Code interactions

## Implementation Details
- Supabase server uses dynamic project reference via `${SUPABASE_PROJECT_REF}` environment variable
- Supabase authentication leverages `${SUPABASE_ACCESS_TOKEN}` environment variable for secure credential management
- Context7 server includes a hardcoded API key in the configuration (note: consider moving to environment variable for security)
- Both servers use HTTP protocol for communication

https://claude.ai/code/session_01Kh1sx7LAkvEHy25yR8Brfh