### PR TITLE
feat(mcp): retirer categories.weight du retour get_requirements_tree

### DIFF
--- a/lib/mcp/tools/get-requirements-tree.ts
+++ b/lib/mcp/tools/get-requirements-tree.ts
@@ -48,8 +48,6 @@ export interface CategoryTreeNode {
   shortName: string;
   level: number;
   displayOrder: number | null;
-  /** Own weight from the categories table */
-  weight: number;
   /** Recursive sum of all requirements weights in this subtree */
   aggregateWeight: number;
   /** Recursive total requirement count (direct + all sub-categories) */
@@ -97,7 +95,6 @@ type RawCategory = {
   level: number;
   parent_id: string | null;
   display_order: number | null;
-  weight: number;
 };
 
 type RawRequirement = {
@@ -141,7 +138,6 @@ function buildTree(
       shortName: cat.short_name,
       level: cat.level,
       displayOrder: cat.display_order,
-      weight: cat.weight ?? 1,
       aggregateWeight: directReqs.reduce((s, r) => s + r.weight, 0),
       requirementCount: directReqs.length,
       mandatoryCount: directReqs.filter((r) => r.isMandatory).length,
@@ -228,7 +224,7 @@ export async function handleGetRequirementsTree(
     await Promise.all([
       supabase
         .from("categories")
-        .select("id, code, title, short_name, level, parent_id, display_order, weight")
+        .select("id, code, title, short_name, level, parent_id, display_order")
         .eq("rfp_id", rfp_id)
         .order("display_order", { ascending: true, nullsFirst: false }),
       supabase


### PR DESCRIPTION
Le champ `weight` des catégories (colonne `categories.weight`, DEFAULT 1.0)
est redondant avec `aggregateWeight` qui est calculé à la volée depuis les
requirements. Le WeightsTab ne le lit jamais au chargement, et la valeur en
base est souvent périmée (122 catégories à la valeur par défaut 1.0).

Seul `aggregateWeight` (somme récursive des requirements.weight du sous-arbre)
est conservé — il est toujours à jour et constitue la source de vérité.

Une issue GitHub devra être créée pour supprimer la colonne en base après
analyse d'impact complète (get-rfp-structure, get-scoring-matrix, edge functions).

https://claude.ai/code/session_014UFUFBznvjrBep6c5QkcvK