### PR TITLE
Add Supabase keep-alive health-check edge function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,21 @@ npx supabase functions deploy <function_name> --project-ref ixxmjmxfzipxmlwmqods
 # Exemples
 npx supabase functions deploy generate-soutenance --project-ref ixxmjmxfzipxmlwmqods --no-verify-jwt
 npx supabase functions deploy generate-soutenance-callback --project-ref ixxmjmxfzipxmlwmqods --no-verify-jwt
+npx supabase functions deploy health-check --project-ref ixxmjmxfzipxmlwmqods --no-verify-jwt
 
 # Ajouter/mettre à jour un secret (variable d'env pour les edge functions)
 npx supabase secrets set MY_VAR=value --project-ref ixxmjmxfzipxmlwmqods
 ```
+
+### Keep-alive Supabase (anti-suspension)
+
+La fonction `health-check` (voir `supabase/functions/health-check`) fait un ping léger sur la table `rfps` pour maintenir l'activité du projet Supabase et éviter la mise en pause automatique après 7 jours d'inactivité (limite du plan gratuit).
+
+Dans N8N, créer un workflow avec :
+1. Un noeud **Schedule Trigger** (ex : tous les 3 jours)
+2. Un noeud **HTTP Request** en `GET` vers `https://<project-ref>.supabase.co/functions/v1/health-check`, avec le header `apikey: <SUPABASE_ANON_KEY>`
+
+La réponse attendue est `{"status":"ok","database":"reachable",...}` avec un code 200.
 
 ## Code Style
 

--- a/supabase/functions/health-check/deno.json
+++ b/supabase/functions/health-check/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "std/": "https://deno.land/std@0.208.0/",
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/health-check/index.ts
+++ b/supabase/functions/health-check/index.ts
@@ -1,0 +1,67 @@
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// Keep-alive endpoint for N8N (or any external scheduler) to ping periodically.
+// Supabase free-tier projects auto-pause after 7 days without activity, so this
+// route performs a trivial DB read to register activity on both the Edge
+// Function runtime and the Postgres database.
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const startedAt = Date.now();
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+    if (!supabaseUrl || !supabaseKey) {
+      throw new Error("Missing Supabase environment variables");
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const { error: dbError } = await supabase
+      .from("rfps")
+      .select("id", { count: "exact", head: true });
+
+    if (dbError) {
+      throw new Error(`Database ping failed: ${dbError.message}`);
+    }
+
+    return new Response(
+      JSON.stringify({
+        status: "ok",
+        database: "reachable",
+        timestamp: new Date().toISOString(),
+        duration_ms: Date.now() - startedAt,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      }
+    );
+  } catch (error) {
+    console.error("[health-check] Error:", error);
+    return new Response(
+      JSON.stringify({
+        status: "error",
+        error: error instanceof Error ? error.message : "Internal server error",
+        timestamp: new Date().toISOString(),
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Add a new `health-check` Supabase Edge Function that runs a lightweight `select` against the `rfps` table to register DB activity
- Intended to be called on a schedule by N8N (e.g. every 3 days) so the free-tier Supabase project doesn't auto-pause after 7 days of inactivity
- Document the deploy command and the N8N Schedule Trigger + HTTP Request setup in `CLAUDE.md`

## Notes
- The function requires no request body/auth beyond the standard `apikey` header (deployed with `--no-verify-jwt`, consistent with the other callback functions in this repo)
- Deployment to the live project (`ixxmjmxfzipxmlwmqods`) needs to be run with your own Supabase credentials — the CLI command is:
  ```bash
  npx supabase functions deploy health-check --project-ref ixxmjmxfzipxmlwmqods --no-verify-jwt
  ```

## Test plan
- [ ] Deploy the function to the Supabase project
- [ ] `curl` the function URL and confirm a `200` with `{"status":"ok","database":"reachable",...}`
- [ ] Configure the N8N Schedule Trigger + HTTP Request node as described in `CLAUDE.md`
- [ ] Confirm the N8N workflow run shows a successful `200` response


---
_Generated by [Claude Code](https://claude.ai/code/session_01LojeDo29SZycWm2ad3hbkj)_